### PR TITLE
fix: Use simpler SVG for hamburger button

### DIFF
--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -55,24 +55,21 @@
 				xmlns="http://www.w3.org/2000/svg"
 			>
 				<rect
-					y="13.5686"
-					width="3.13043"
-					height="24"
-					transform="rotate(-90 0 13.5686)"
+					y="0"
+					height="3"
+					width="24"
 					fill={onHomepage ? 'white' : 'black'}
 				/>
 				<rect
-					y="3.13037"
-					width="3.13043"
-					height="24"
-					transform="rotate(-90 0 3.13037)"
+					y="10.5"
+					height="3"
+					width="24"
 					fill={onHomepage ? 'white' : 'black'}
 				/>
 				<rect
-					y="24"
-					width="3.13043"
-					height="24"
-					transform="rotate(-90 0 24)"
+					y="21"
+					height="3"
+					width="24"
 					fill={onHomepage ? 'white' : 'black'}
 				/>
 			</svg>


### PR DESCRIPTION
Current SVG, introduced in ccb369fd, is weird :wink:  (because it draws vertical rectangles then rotate them), but more importantly is imperfectly drawn by browsers (middle rectangle is larger than the other ones):

![image](https://github.com/user-attachments/assets/94d327dc-8dd1-46df-8086-76102b54fb6c)
