### PR TITLE
Fix videos aspect ratio

### DIFF
--- a/src/lib/components/home/videos.svelte
+++ b/src/lib/components/home/videos.svelte
@@ -23,6 +23,7 @@
 	.video-grid :global(iframe) {
 		aspect-ratio: 16 / 9;
 		width: 100%;
+		height: unset;
 	}
 
 	@media (min-width: 768px) {


### PR DESCRIPTION
The iframes have an inherit height which needs to be unset.